### PR TITLE
Add GIF as separate media type

### DIFF
--- a/src/media.rs
+++ b/src/media.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 pub enum MediaType {
     Photo,
     Video,
+    Gif,
 }
 
 impl MediaType {
@@ -11,11 +12,15 @@ impl MediaType {
         match self {
             Self::Photo => {
                 //Missing either CreateDate or DatetimeOriginal
-                "((not $Exif:CreateDate or not $Exif:DatetimeOriginal) and $MIMEType=~/image/)"
+                "((not $Exif:CreateDate or not $Exif:DatetimeOriginal) and $MIMEType=~/image/ and not $FileType eq \"GIF\")"
             }
             Self::Video => {
                 //Missing CreateDate in both groups
                 "(not $QuickTime:CreateDate and not $Xmp:CreateDate and $MIMEType=~/video/)"
+            }
+            Self::Gif => {
+                //Like a photo but with a different tag group
+                "((not $Xmp:CreateDate or not $Xmp:DatetimeOriginal) and $MIMEType=~/image/ and $FileType eq \"GIF\")"
             }
         }
     }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, env, fs::File, process::Command};
 
 fn scan(ty: MediaType) -> Result<Vec<String>> {
     let stdout = Command::new(env::var("EXIFTOOL")?)
-        .args(["-s", "FilePath"])
+        .args(["-s", "-FilePath"])
         .args(["-if", ty.exif_condition()])
         .args(["-r", "/Photos"])
         .args(["-i", "@eaDir"])
@@ -22,7 +22,7 @@ fn scan(ty: MediaType) -> Result<Vec<String>> {
 
 pub fn scan_all() -> Result<()> {
     let mut map = HashMap::new();
-    for ty in [MediaType::Photo, MediaType::Video] {
+    for ty in [MediaType::Photo, MediaType::Video, MediaType::Gif] {
         map.insert(ty, scan(ty)?);
     }
 


### PR DESCRIPTION
This PR adds gifs as a new media type separate from photos. It is motivated by gifs using the XMP tag group instead of EXIF.